### PR TITLE
Bugfix: anchored links on the homepage

### DIFF
--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -25,19 +25,19 @@ Following the standards and guidance will help you deliver good services for use
   <ul>
     <li class="card">
         <div class="text">
-            <h2><a href="/design-standards/">Design standards</a></h2>
+            <h2 id="design-standards"><a href="/design-standards/">Design standards</a></h2>
             <p>The design and accessibility standards that all designers working on digital services must meet.</p>
         </div>
-    </li>  
+    </li>
     <li class="card">
         <div class="text">
-            <h2><a href="/patterns-and-components/">Patterns and components</a></h2>
+            <h2 id="patterns-and-components"><a href="/patterns-and-components/">Patterns and components</a></h2>
             <p>Patterns and components designed specifically for DfE users or iterated from GOV Design System.</p>
         </div>
     </li>
       <li class="card">
         <div class="text">
-            <h2><a href="/design-assurance/">Design assurance</a></h2>
+            <h2 id="design-assurance"><a href="/design-assurance/">Design assurance</a></h2>
             <p>Making sure you're working to good practices, meeting standards and sharing knowledge and experience across professions.</p>
         </div>
     </li>
@@ -50,7 +50,7 @@ Following the standards and guidance will help you deliver good services for use
 <div class="dfe-panel">
 <div class="govuk-grid-row">
 <div class="govuk-grid-column-two-thirds">
-    <h2><a href="/content-design/">Content design</a></h2>
+    <h2 id="content-design"><a href="/content-design/">Content design</a></h2>
  <p>Content guidelines for how we write for DfE services.</p>
   </div>
    <div class="govuk-grid-column-one-third standards-icon">
@@ -62,7 +62,7 @@ Following the standards and guidance will help you deliver good services for use
 <div class="dfe-panel">
 <div class="govuk-grid-row">
 <div class="govuk-grid-column-two-thirds">
-    <h2><a href="/interaction-design/">Interaction design</a></h2>
+    <h2 id="interaction-design"><a href="/interaction-design/">Interaction design</a></h2>
  <p>Good practice, principles and ways of working for interaction designers.</p>
   </div>
    <div class="govuk-grid-column-one-third standards-icon">
@@ -74,7 +74,7 @@ Following the standards and guidance will help you deliver good services for use
 <div class="dfe-panel">
 <div class="govuk-grid-row">
 <div class="govuk-grid-column-two-thirds">
-    <h2><a href="/service-design/">Service design</a></h2>
+    <h2 id="service-design"><a href="/service-design/">Service design</a></h2>
  <p>Methodologies and processes for designing good services.</p>
   </div>
    <div class="govuk-grid-column-one-third standards-icon">


### PR DESCRIPTION
This fixes a bug caused by the [anchored headings](https://github.com/alphagov/tech-docs-gem/blob/master/lib/assets/javascripts/_modules/anchored-headings.js) feature inherited from the `govuk_tech_docs` gem. This javascript injects an anchor link for each heading which becomes visible on hover, displaying as a link-in-chain icon.

Unfortunately, this link expects there to be an `id` attribute set on each heading, and otherwise links to `#undefined`, which doesn't work.

This fixes the links by adding the required id attributes.

It's still a slightly odd behaviour on the homepage, where these headings are already links to other pages, and so the anchor link is probably not that useful and possibly confusing.  Unfortunately, the javascript doesn't have any ability to opt-out of this behaviour, other than by using another element such as a `<div>` instead of the  `<h2>`. We could possibly override it with some slightly hacky additional javascript or CSS, but that doesn't seem ideal.

So in the short term perhaps we should keep this feature and just fix it so that the anchor links work?

## Screenshot showing bug

<img width="913" alt="Screenshot 2022-07-04 at 17 09 32" src="https://user-images.githubusercontent.com/30665/177190424-f49c6e75-4c4a-4c18-888c-6bdc02897501.png">


